### PR TITLE
added custom_attributes to category when fetching details

### DIFF
--- a/src/main/java/com/github/chen0040/magento/models/Category.java
+++ b/src/main/java/com/github/chen0040/magento/models/Category.java
@@ -1,12 +1,10 @@
 package com.github.chen0040.magento.models;
 
-
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
-
 
 /**
  * Created by xschen on 12/6/2017.
@@ -14,12 +12,13 @@ import java.util.List;
 @Setter
 @Getter
 public class Category {
-   private long id = 2;
-   private long parent_id = 1;
-   private String name = "Category Store Group 1 - website_id_1";
-   private boolean is_active = true;
-   private int position = 1;
-   private int level = 1;
-   private int product_count = 25;
-   private List<Category> children_data = new ArrayList<>();
+  private long id = 2;
+  private long parent_id = 1;
+  private String name = "Category Store Group 1 - website_id_1";
+  private boolean is_active = true;
+  private int position = 1;
+  private int level = 1;
+  private int product_count = 25;
+  List<CategoryAttribute> custom_attributes = new ArrayList<>();
+  private List<Category> children_data = new ArrayList<>();
 }

--- a/src/main/java/com/github/chen0040/magento/models/CategoryAttribute.java
+++ b/src/main/java/com/github/chen0040/magento/models/CategoryAttribute.java
@@ -1,6 +1,7 @@
 package com.github.chen0040.magento.models;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Setter
 @Getter

--- a/src/main/java/com/github/chen0040/magento/models/CategoryAttribute.java
+++ b/src/main/java/com/github/chen0040/magento/models/CategoryAttribute.java
@@ -1,0 +1,11 @@
+package com.github.chen0040.magento.models;
+
+import lombok.Data;
+
+@Data
+public class CategoryAttribute {
+
+  private String attribute_code;
+
+  private String value;
+}

--- a/src/main/java/com/github/chen0040/magento/models/CategoryAttribute.java
+++ b/src/main/java/com/github/chen0040/magento/models/CategoryAttribute.java
@@ -2,7 +2,8 @@ package com.github.chen0040.magento.models;
 
 import lombok.Data;
 
-@Data
+@Setter
+@Getter
 public class CategoryAttribute {
 
   private String attribute_code;


### PR DESCRIPTION
Add custom_attributes to category so that when a category is fetched with MagentoCategoryManager.getCategoryByIdClean(id) the custom_attributes are set
 - useful when url_key and url_path is required ...